### PR TITLE
Fix falling mob mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # Vectorientation
-A clientside minecraft mod for enhancing the visuals of falling blocks
+
+Vectorientation is a client‑side mod for Minecraft that adds squash and stretch
+effects to falling blocks and certain entities. Blocks and TNT rotate to match
+their motion, while mobs can optionally squish when moving vertically.
+
+## Building
+
+This project uses [Gradle](https://gradle.org/). To create a mod jar run:
+
+```bash
+./gradlew build
+```
+
+The output will be located in `build/libs/`.
+
+## Installation
+
+Copy the generated jar to your Minecraft `mods` folder along with Fabric
+Loader and Fabric API for the target game version.
+
+## Configuration
+
+On first launch a configuration file is created in your game directory. It
+contains options to enable the squash effect (`squetch`), adjust how much it
+increases with speed (`warp_factor`), and define a blacklist of blocks that
+should not be affected.
+
+## Features
+
+- Falling blocks align with their velocity and stretch as they fall.
+- TNT and minecarts get similar treatment.
+- Mobs can squish when moving up or down if the option is enabled.

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/src/main/java/vectorientation/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/vectorientation/mixin/LivingEntityRendererMixin.java
@@ -1,0 +1,36 @@
+package vectorientation.mixin;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vectorientation.main.Vectorientation;
+
+@Mixin(LivingEntityRenderer.class)
+public abstract class LivingEntityRendererMixin<T extends LivingEntity> {
+    @Inject(
+            method = "Lnet/minecraft/client/render/entity/LivingEntityRenderer;render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
+            at = @At("HEAD")
+    )
+    private void vectorientation$applySquish(T entity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
+        matrixStack.push();
+        if (!entity.isOnGround() && Vectorientation.SQUETCH) {
+            Vec3d vel = entity.getVelocity();
+            float speed = (float) (Vectorientation.MIN_WARP + Vectorientation.WARP_FACTOR * Math.abs(vel.y));
+            matrixStack.scale(1.0F / speed, speed, 1.0F / speed);
+        }
+    }
+
+    @Inject(
+            method = "Lnet/minecraft/client/render/entity/LivingEntityRenderer;render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
+            at = @At("TAIL")
+    )
+    private void vectorientation$popMatrix(T entity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
+        matrixStack.pop();
+    }
+}

--- a/src/main/resources/vectorientation.mixins.json
+++ b/src/main/resources/vectorientation.mixins.json
@@ -9,7 +9,8 @@
     "FallingBlockEntityRenderStateMixin",
     "FallingBlockRendererMixin",
     "TntEntityRenderStateMixin",
-    "TntEntityRendererMixin"
+    "TntEntityRendererMixin",
+    "LivingEntityRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- update README with build instructions and feature overview
- align Java compatibility to 17
- fix LivingEntityRenderer mixin descriptor to match class name

## Testing
- `./gradlew build --no-daemon` *(fails to download Gradle distribution)*